### PR TITLE
Fix URL for first tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Node provides the RESTful API. Angular provides the frontend and accesses the AP
 This repo corresponds to the Node Todo Tutorial Series on [scotch.io](http://scotch.io)
 
 Each branch represents a certain tutorial.
-- tut1-starter: [Creating a Single Page Todo App with Node and Angular](http://scotch.io/tutorials/javascript/creating-a-single-page-todo-app-with-node-and-angular)
+- tut1-starter: [Creating a Single Page Todo App with Node and Angular](https://scotch.io/tutorials/creating-a-single-page-todo-app-with-node-and-angular)
 - tut2-organization: [Application Organization and Structure](https://scotch.io/tutorials/node-and-angular-to-do-app-application-organization-and-structure)
 - tut3-services: [Controllers and Services](https://scotch.io/tutorials/node-and-angular-to-do-app-controllers-and-services)
 


### PR DESCRIPTION
First tutorial link was stale, this PR just updates it to the currently valid URL on scotch.io